### PR TITLE
Doc updates on Security, User permissions, Dockerfile build and runtime behavior, and Secrets Handling

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,7 @@
   * [Use multiple FROMs to create multi-stage builds](docker-commands/dockerfile-instructions/use-multiple-froms-to-create-multi-stage-builds.md)
   * [Docker Container File System](docker-commands/dockerfile-instructions/docker-container-file-system.md)
   * [Passing ENV variables, ARGs and Configurations](docker-commands/dockerfile-instructions/passing-env-variables-args-and-configurations.md)
+  * [Use of root vs non-root user](docker-commands/dockerfile-instructions/use-of-root-vs-non-root-user.md)
 * [Docker Compose Commands & Features](docker-commands/docker-compose-commands-and-features.md)
 * [Hands On](docker-commands/hands-on/README.md)
   * [Basic Docker Commands](docker-commands/hands-on/basic-docker-commands.md)

--- a/docs/docker-commands/dockerfile-instructions/README.md
+++ b/docs/docker-commands/dockerfile-instructions/README.md
@@ -95,3 +95,7 @@ FROM scratch
 [passing-env-variables-args-and-configurations.md](passing-env-variables-args-and-configurations.md)
 {% endcontent-ref %}
 
+
+
+Use of Root , Non Root User
+

--- a/docs/docker-commands/dockerfile-instructions/passing-env-variables-args-and-configurations.md
+++ b/docs/docker-commands/dockerfile-instructions/passing-env-variables-args-and-configurations.md
@@ -250,6 +250,50 @@ exec "$@"
 ```
 {% endcode %}
 
+#### ❗How ENV variables actually persist; Get backed into the Image
+
+1. Anything you put in an `ENV` instruction or `ARG` instruction stays in the image metadata forever, since they are used at image build time.
+2. ✅ But environment variables set via an `ENTRYPOINT` instruction is set at runtime, so they don't get baked into the image layer.
+
+❌<br>
+
+#### **Docker BuildKit Secret Mounts** ✅ (Recommended)
+
+{% hint style="info" %}
+This is the **industry standard** for handling secrets during build.
+{% endhint %}
+
+{% code title="Dockerfile" %}
+```docker
+# syntax=docker/dockerfile:1
+
+FROM node:18 AS builder
+# Mount secret at build time (never persisted in layers)
+RUN --mount=type=secret,id=npm_token \
+    NPM_TOKEN=$(cat /run/secrets/npm_token) && \
+    npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN && \
+    npm install
+
+FROM node:18 AS runtime
+COPY --from=builder /app/node_modules ./node_modules
+# Secrets are NOT in this layer
+```
+{% endcode %}
+
+Build with:
+
+{% code title="bash" %}
+```bash
+docker build --secret id=npm_token,src=.npm_token .
+```
+{% endcode %}
+
+**Benefits:**
+
+* Secrets never stored in image layers
+* Can't be extracted from final image
+* Secure and auditable
+
 
 
 ## Handling Complex Configurations

--- a/docs/docker-commands/dockerfile-instructions/use-multiple-froms-to-create-multi-stage-builds.md
+++ b/docs/docker-commands/dockerfile-instructions/use-multiple-froms-to-create-multi-stage-builds.md
@@ -61,3 +61,54 @@ COPY --from=build /app/target/file.war /usr/local/tomcat/webapps
 * **Simple apps** where build and runtime environments are identical and small — a single-stage image is simpler
 * **When you need every build-step filesystem state preserved** in the final image (multi-stage intentionally discards intermediate state)
 
+#### <mark style="color:blue;">Naming Suggestions for Multiple Stages</mark>
+
+* `prepare` — general-purpose stage for copying files and fetching packages (recommended)
+* `deps` — when the stage’s primary job is installing dependency packages
+* `setup` — clear intent to configure environment and fetch artifacts
+* `bootstrap` — if it bootstraps the build environment (downloads toolchains, etc.)
+* `builder` — when this stage also compiles/builds artifacts (common convention)
+* `fetch` — when it only pulls/downloads external assets
+* `assets` — for copying static assets from host + fetching related packages
+* `runtime-deps` — when preparing runtime-only dependencies (separates from build deps)
+
+
+
+## Multi Stages with Multiple Entrypoints
+
+**`ENTRYPOINT ["/entrypoint3.sh"]` itself does NOT execute during build**, but if your script is being run via `RUN` or setting `ENV` variables, those will persist.
+
+{% code title="Dockerfile" %}
+```dockerfile
+FROM image1 as stage1
+ENTRYPOINT [entrypoint1.sh]
+CMD [/bin/bash]
+
+FROM image2 as stage2
+ENTRYPOINT [entrypoint2.sh]
+CMD [/bin/bash]
+
+FROM image3 as stage3
+ENTRYPOINT [entrypoint3.sh]
+CMD [/bin/bash]
+```
+{% endcode %}
+
+#### What happens when you run `docker run`
+
+When you execute `docker run <final-image>`, **only `entrypoint3.sh` gets executed**, assuming the final image is built from `stage3`.
+
+In a multi-stage Dockerfile, the rule of thumb is: The last one wins.&#x20;
+
+* When you run `docker run` on an image built from this Dockerfile, only the final stage (e.g: `stage3`) determines what actually happens.&#x20;
+* The previous stages are essentially temporary "workshops" used during the build process.
+
+<mark style="color:blue;">**Why Only the Last Stage?**</mark>
+
+1. **Multi-stage builds are sequential**: Each stage builds upon or uses artifacts from previous stages, but only the **last `FROM` instruction** determines the base image of the final output.
+2. **Earlier stages are discarded**: After the build completes, `stage1` and `stage2` exist only temporarily during the build process. They're not part of the final image unless you explicitly copy files from them using `COPY --from=stage1` or `COPY --from=stage2`.&#x20;
+   * But, even if you don't explicitly copy files from `stage1` and `stage2`, and if the build targets( i.e. ends in ) `stage2`, that case, `entrypoint2.sh` will be run upon calling `docker run`.
+3. **Only one ENTRYPOINT per image**: A Docker image can only have **one** `ENTRYPOINT` and **one** `CMD`. The final stage's instructions override all previous ones.
+
+<br>
+

--- a/docs/docker-commands/dockerfile-instructions/use-of-root-vs-non-root-user.md
+++ b/docs/docker-commands/dockerfile-instructions/use-of-root-vs-non-root-user.md
@@ -1,0 +1,39 @@
+---
+icon: user-group
+---
+
+# Use of root vs non-root user
+
+## Use of root vs non-root user
+
+{% hint style="info" %}
+#### The principle:&#x20;
+
+least privilege — give the container only the privileges it needs
+{% endhint %}
+
+✅ Prefer a **non-root user** for containers you build for production.&#x20;
+
+✅ Run as **root** **only when** you must (e.g., for setup steps or when the process truly requires root capabilities).&#x20;
+
+#### Why non-root is recommended (plain language)
+
+* Security: If an attacker escapes the app/process, a non-root process has fewer privileges to damage the host or other containers.
+* Defense-in-depth: Many layers (Docker, kernel, namespaces) help isolate containers — but running as root inside the container weakens those layers.
+* Compliance & best practice: Many security scanners, CI checks and cloud providers flag or block root containers.
+* Predictability: Files created by the container will use a known UID/GID instead of root:root which can cause surprises with host-mounted volumes.
+
+#### When root inside container is OK or required
+
+* Building or installing system packages in image layers (RUN apt-get …) usually needs root, but you can drop to non-root afterwards.
+* Binding to privileged ports (<1024) or using capabilities (net admin, mounting, etc.) may require root or granting specific capabilities — better alternatives exist (setcap, reverse proxy, port mapping).
+* Local development: sometimes running as root is convenient, but prefer matching production behavior early.
+
+#### Practical issues to watch for
+
+* Volumes and host mounts: If you mount a host directory, the host’s filesystem permissions apply. A non-root user inside the container may not have access unless you:
+  * Make the mounted files accessible on the host, or
+  * Run container with --user to match the host UID, or
+  * In entrypoint, chown files (but chown on large volumes may be slow).
+* Binding to port 80/443: Instead of running as root, use Docker’s port mapping (docker run -p 80:8080) or give only the executable the capability to bind lower ports via setcap.
+* When you need a specific UID/GID (e.g., to match host user), create the user with that UID/GID in the Dockerfile.


### PR DESCRIPTION
# Security, User permissions, Dockerfile build and runtime behavior, and Secrets Handling

This pull request adds new documentation and expands existing guides to provide clearer explanations on Dockerfile best practices, including user permissions, environment variable handling, multi-stage builds, and secret management. The changes aim to improve security guidance, clarify Docker build behaviors, and offer practical advice for production-ready container images.

**Security and User Permissions:**
* Added a new guide `use-of-root-vs-non-root-user.md` explaining the principle of least privilege, why running containers as a non-root user is recommended, and practical considerations for handling volumes and ports.
* Linked the new guide in `SUMMARY.md` for easier navigation.

**Dockerfile Build and Runtime Behavior:**
* Expanded the multi-stage build guide with naming conventions for stages and clarified how `ENTRYPOINT` and `CMD` instructions behave in multi-stage Dockerfiles, emphasizing that only the final stage's entrypoint is executed at runtime.

**Environment Variables and Secrets Handling:**
* Improved the explanation of how environment variables persist in Docker images, distinguishing between build-time and runtime settings.
* Added a section on Docker BuildKit secret mounts, showing how to securely handle secrets during image builds without persisting them in image layers.

**Documentation Structure:**
* Introduced a new section header in the Dockerfile instructions README for "Use of Root, Non Root User," preparing for further content expansion.